### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/pardom/CleanNews.png?label=ready&title=Ready)](https://waffle.io/pardom/CleanNews)
 [![Build Status](https://travis-ci.org/pardom/CleanNews.svg?branch=master)](https://travis-ci.org/pardom/CleanNews)
 
 # CleanNews


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/pardom/CleanNews

This was requested by a real person (user pardom) on waffle.io, we're not trying to spam you.
